### PR TITLE
Wildcard deletion ability (GSI-917)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,7 +106,8 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: Deletes all or some documents in the collection.
+      summary: Deletes all or some documents in the collection. No error is raised
+        if db or collection do not exist.
       tags:
       - StateManagementService
       - sms-mongodb

--- a/src/sms/adapters/inbound/fastapi_/routes.py
+++ b/src/sms/adapters/inbound/fastapi_/routes.py
@@ -171,7 +171,8 @@ async def upsert_docs(
     "/documents/{namespace}",
     operation_id="delete_documents",
     tags=["StateManagementService", "sms-mongodb"],
-    summary="Deletes all or some documents in the collection.",
+    summary="Deletes all or some documents in the collection. No error is raised if db"
+    + " or collection do not exist.",
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_docs(

--- a/src/sms/adapters/inbound/fastapi_/routes.py
+++ b/src/sms/adapters/inbound/fastapi_/routes.py
@@ -122,7 +122,7 @@ async def get_docs(
     except DocsHandlerPort.CriteriaFormatError as err:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Check query parameters: {err}",
+            detail=str(err),
         ) from err
 
 
@@ -202,8 +202,8 @@ async def delete_docs(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(err),
         ) from err
-    except DocsHandlerPort.CriteriaFormatError as err:
+    except (DocsHandlerPort.CriteriaFormatError, ValueError) as err:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Check query parameters: {err}",
+            detail=str(err),
         ) from err

--- a/src/sms/adapters/outbound/docs_dao.py
+++ b/src/sms/adapters/outbound/docs_dao.py
@@ -89,21 +89,32 @@ class DocsDao(DocsDaoPort):
         """
         await self._client[db_name][collection].delete_many(criteria)
 
-    async def get_db_map_for_prefix(self, prefix: str) -> dict[str, list[str]]:
-        """Get a dict containing a list of collections for each database.
+    async def get_db_map_for_prefix(
+        self, *, prefix: str, db_name: str | None = None
+    ) -> dict[str, list[str]]:
+        """Get a dict containing a list of collections for each database, or a specific
+        database (if `db_name` is provided).
 
         Only returns databases that start with the given prefix, and it returns the
         database names with `prefix` stripped. An empty dict is returned if `prefix` is
-        empty.
+        empty. If `db_name` is provided but no collections exist, an empty list is
+        returned with the database name as the key.
         """
-        return (
-            {
-                db.removeprefix(prefix): sorted(
-                    await self._client[db].list_collection_names()
+        if not prefix:
+            return {}
+
+        if db_name:
+            full_db_name = f"{prefix}{db_name}"
+            return {
+                db_name: sorted(
+                    await self._client[full_db_name].list_collection_names()
                 )
-                for db in await self._client.list_database_names()
-                if db.startswith(prefix)
             }
-            if prefix
-            else {}
-        )
+
+        return {
+            db.removeprefix(prefix): sorted(
+                await self._client[db].list_collection_names()
+            )
+            for db in await self._client.list_database_names()
+            if db.startswith(prefix)
+        }

--- a/src/sms/adapters/outbound/docs_dao.py
+++ b/src/sms/adapters/outbound/docs_dao.py
@@ -82,6 +82,8 @@ class DocsDao(DocsDaoPort):
     ) -> None:
         """Delete documents satisfying the criteria.
 
+        No error is raised if the db or collection does not exist.
+
         Args:
         - `db_name`: The database name.
         - `collection`: The collection name.

--- a/src/sms/adapters/outbound/docs_dao.py
+++ b/src/sms/adapters/outbound/docs_dao.py
@@ -88,3 +88,22 @@ class DocsDao(DocsDaoPort):
         - `criteria`: The criteria to use for filtering the documents (mapping)
         """
         await self._client[db_name][collection].delete_many(criteria)
+
+    async def get_db_map_for_prefix(self, prefix: str) -> dict[str, list[str]]:
+        """Get a dict containing a list of collections for each database.
+
+        Only returns databases that start with the given prefix, and it returns the
+        database names with `prefix` stripped. An empty dict is returned if `prefix` is
+        empty.
+        """
+        return (
+            {
+                db.removeprefix(prefix): sorted(
+                    await self._client[db].list_collection_names()
+                )
+                for db in await self._client.list_database_names()
+                if db.startswith(prefix)
+            }
+            if prefix
+            else {}
+        )

--- a/src/sms/core/docs_handler.py
+++ b/src/sms/core/docs_handler.py
@@ -219,6 +219,8 @@ class DocsHandler(DocsHandlerPort):
         collection in all databases is not allowed in order to prevent accidental data
         loss.
 
+        No error is raised if the db or collection does not exist.
+
         Args:
         - `db_name`: The name of the database.
         - `collection`: The name of the collection.

--- a/src/sms/core/docs_handler.py
+++ b/src/sms/core/docs_handler.py
@@ -16,12 +16,15 @@
 
 import json
 import logging
+from contextlib import suppress
 from typing import Literal, NamedTuple
 
 from sms.config import Config
 from sms.models import Criteria, DocumentType, UpsertionDetails
 from sms.ports.inbound.docs_handler import DocsHandlerPort
 from sms.ports.outbound.docs_dao import DocsDaoPort
+
+log = logging.getLogger(__name__)
 
 
 def log_and_raise_permissions_error(
@@ -33,7 +36,7 @@ def log_and_raise_permissions_error(
         f"'{operation.title()}' operations not allowed on db '{db_name}',"
         + f" collection '{collection}'. No rule found that matches '{rule}'",
     )
-    logging.error(
+    log.error(
         error,
         extra={"db_name": db_name, "collection": collection, "operation": operation},
     )
@@ -104,7 +107,7 @@ class DocsHandler(DocsHandlerPort):
                     parsed_criteria[key] = json.loads(value)
                 except json.JSONDecodeError as err:
                     error = self.CriteriaFormatError(key=key)
-                    logging.error(
+                    log.error(
                         error,
                         extra={"key": key, "value": value},
                     )
@@ -138,7 +141,7 @@ class DocsHandler(DocsHandlerPort):
             )
         except Exception as err:
             error = self.ReadOperationError(criteria=criteria)
-            logging.error(error)
+            log.error(error)
             raise error from err
 
         return results
@@ -185,14 +188,36 @@ class DocsHandler(DocsHandlerPort):
             )
         except Exception as err:
             error = self.UpsertionError(id_field=id_field)
-            logging.error(
+            log.error(
                 error,
                 extra={"documents": documents},
             )
             raise error from err
 
+    async def _delete(self, db_name: str, collection: str, criteria: Criteria) -> None:
+        """Delete documents satisfying the criteria. Called by the public delete method."""
+        if not self._permissions.can_write(db_name, collection):
+            log_and_raise_permissions_error(db_name, collection, "write")
+
+        full_db_name = f"{self._prefix}{db_name}"
+
+        try:
+            await self._docs_dao.delete(
+                db_name=full_db_name, collection=collection, criteria=criteria
+            )
+        except Exception as err:
+            error = self.DeletionError(criteria=criteria)
+            log.error(error)
+            raise error from err
+
     async def delete(self, db_name: str, collection: str, criteria: Criteria) -> None:
         """Delete documents satisfying the criteria.
+
+        If the wildcard for both db_name and collection is used, all data from all
+        collections is deleted. If a db is specified but the collection is a wildcard,
+        all collections in that db are deleted. However, deleting data from a specific
+        collection in all databases is not allowed in order to prevent accidental data
+        loss.
 
         Args:
         - `db_name`: The name of the database.
@@ -204,17 +229,36 @@ class DocsHandler(DocsHandlerPort):
         - `OperationError`: If the operation fails in the database for any reason.
         - `CriteriaFormatError`: If the filter criteria format is invalid.
         """
-        if not self._permissions.can_write(db_name, collection):
-            log_and_raise_permissions_error(db_name, collection, "write")
+        to_delete: list[tuple[str, str]] = []
+
+        if collection == "*":
+            # Get a list of database and collection names for all dbs with the prefix
+            db_map: dict[str, list[str]] = await self._docs_dao.get_db_map_for_prefix(
+                self._prefix
+            )
+
+            # Set to all collections in all databases if db_name is a wildcard
+            # otherwise just the collections under the specified database
+            to_delete = (
+                [(db, collection) for db in db_map for collection in db_map[db]]
+                if db_name == "*"
+                else [(db_name, coll) for coll in db_map[db_name]]
+            )
+        elif db_name == "*":
+            error = ValueError(
+                "Cannot use wildcard for db_name with specific collection"
+            )
+            log.error(error)
+            raise error
 
         parsed_criteria = self._parse_criteria(criteria)
-        full_db_name = f"{self._prefix}{db_name}"
-
-        try:
-            await self._docs_dao.delete(
-                db_name=full_db_name, collection=collection, criteria=parsed_criteria
+        if to_delete:
+            log.debug("Iteratively deleting data from these collections: %s", to_delete)
+            for db, coll in to_delete:
+                with suppress(PermissionError):
+                    await self._delete(db, coll, parsed_criteria)
+        else:
+            log.debug(
+                "Deleting data from a specific collection: %s", (db_name, collection)
             )
-        except Exception as err:
-            error = self.DeletionError(criteria=criteria)
-            logging.error(error)
-            raise error from err
+            await self._delete(db_name, collection, parsed_criteria)

--- a/src/sms/core/docs_handler.py
+++ b/src/sms/core/docs_handler.py
@@ -233,17 +233,17 @@ class DocsHandler(DocsHandlerPort):
 
         if collection == "*":
             # Get a list of database and collection names for all dbs with the prefix
-            db_map: dict[str, list[str]] = await self._docs_dao.get_db_map_for_prefix(
-                self._prefix
+            # if db is wildcard, otherwise just the collections under the specified db
+            db_map: dict[str, list[str]] = (
+                await self._docs_dao.get_db_map_for_prefix(prefix=self._prefix)
+                if db_name == "*"
+                else await self._docs_dao.get_db_map_for_prefix(
+                    prefix=self._prefix, db_name=db_name
+                )
             )
 
-            # Set to all collections in all databases if db_name is a wildcard
-            # otherwise just the collections under the specified database
-            to_delete = (
-                [(db, collection) for db in db_map for collection in db_map[db]]
-                if db_name == "*"
-                else [(db_name, coll) for coll in db_map[db_name]]
-            )
+            # Make a list of tuples representing the (db, collection)s to delete
+            to_delete = [(db, collection) for db in db_map for collection in db_map[db]]
         elif db_name == "*":
             error = ValueError(
                 "Cannot use wildcard for db_name with specific collection"

--- a/src/sms/ports/inbound/docs_handler.py
+++ b/src/sms/ports/inbound/docs_handler.py
@@ -53,7 +53,7 @@ class DocsHandlerPort(ABC):
         """Raised when the criteria format is invalid."""
 
         def __init__(self, *, key: str):
-            super().__init__(f"The value for key '{key}' is invalid.")
+            super().__init__(f"The value for query parameter '{key}' is invalid.")
 
     @abstractmethod
     async def get(

--- a/src/sms/ports/inbound/docs_handler.py
+++ b/src/sms/ports/inbound/docs_handler.py
@@ -96,6 +96,14 @@ class DocsHandlerPort(ABC):
     async def delete(self, db_name: str, collection: str, criteria: Criteria) -> None:
         """Delete documents satisfying the criteria.
 
+        If the wildcard for both db_name and collection is used, all data from all
+        collections is deleted. If a db is specified but the collection is a wildcard,
+        all collections in that db are deleted. However, deleting data from a specific
+        collection in all databases is not allowed in order to prevent accidental data
+        loss.
+
+        No error is raised if the db or collection does not exist.
+
         Args:
         - `db_name`: The name of the database.
         - `collection`: The name of the collection.

--- a/src/sms/ports/outbound/docs_dao.py
+++ b/src/sms/ports/outbound/docs_dao.py
@@ -68,11 +68,15 @@ class DocsDaoPort(ABC):
         ...
 
     @abstractmethod
-    async def get_db_map_for_prefix(self, prefix: str) -> dict[str, list[str]]:
-        """Get a dict containing a list of collections for each database.
+    async def get_db_map_for_prefix(
+        self, *, prefix: str, db_name: str | None = None
+    ) -> dict[str, list[str]]:
+        """Get a dict containing a list of collections for each database, or a specific
+        database (if `db_name` is provided).
 
         Only returns databases that start with the given prefix, and it returns the
         database names with `prefix` stripped. An empty dict is returned if `prefix` is
-        empty.
+        empty. If `db_name` is provided but no collections exist, an empty list is
+        returned with the database name as the key.
         """
         ...

--- a/src/sms/ports/outbound/docs_dao.py
+++ b/src/sms/ports/outbound/docs_dao.py
@@ -66,3 +66,13 @@ class DocsDaoPort(ABC):
         - `criteria`: The criteria to use for filtering the documents (mapping)
         """
         ...
+
+    @abstractmethod
+    async def get_db_map_for_prefix(self, prefix: str) -> dict[str, list[str]]:
+        """Get a dict containing a list of collections for each database.
+
+        Only returns databases that start with the given prefix, and it returns the
+        database names with `prefix` stripped. An empty dict is returned if `prefix` is
+        empty.
+        """
+        ...

--- a/src/sms/ports/outbound/docs_dao.py
+++ b/src/sms/ports/outbound/docs_dao.py
@@ -60,6 +60,8 @@ class DocsDaoPort(ABC):
     ) -> None:
         """Delete documents satisfying the criteria.
 
+        No error is raised if the db or collection does not exist.
+
         Args:
         - `db_name`: The database name.
         - `collection`: The collection name.

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -9,3 +9,5 @@ db_permissions:
 - "testdb.writeonly:w"
 - "testdb.readwrite:rw"
 - "testdb.allops:*"
+- "testdb2.writeonly:w"
+- "testdb3.readonly:r"

--- a/tests/integration/test_docs.py
+++ b/tests/integration/test_docs.py
@@ -88,7 +88,7 @@ async def test_get_docs(
     [
         (
             "?age={unquoted_key:53}",
-            "Check query parameters: The value for key 'age' is invalid.",
+            "The value for query parameter 'age' is invalid.",
         ),
         (
             "?age=34&age=33",

--- a/tests/unit/test_docs_dao.py
+++ b/tests/unit/test_docs_dao.py
@@ -118,3 +118,21 @@ async def test_get_db_map_for_prefix(mongodb: MongoDbFixture):
         assert await docs_dao.get_db_map_for_prefix(
             prefix=config.db_prefix, db_name="nonexistent"
         ) == {"nonexistent": []}
+
+
+async def test_deletion_on_nonexistent_resources(mongodb: MongoDbFixture):
+    """Test delete method on nonexistent dbs, collections.
+
+    There should not be any error raised.
+    """
+    config = get_config(sources=[mongodb.config])
+
+    async with DocsDao(config=config) as docs_dao:
+        await docs_dao._client["exists"]["exists"].insert_one({"key": "value"})
+        # Delete nonexistent db contents
+        await docs_dao.delete(
+            db_name="nonexistent", collection="nonexistent", criteria={}
+        )
+
+        # Delete nonexistent collection contents
+        await docs_dao.delete(db_name="exists", collection="nonexistent", criteria={})

--- a/tests/unit/test_docs_dao.py
+++ b/tests/unit/test_docs_dao.py
@@ -80,3 +80,31 @@ async def test_all_ops(mongodb: MongoDbFixture):
         # Delete all docs
         await docs_dao.delete(db_name=TESTDB, collection=ALLOPS, criteria={})
         assert not await docs_dao.get(db_name=TESTDB, collection=ALLOPS, criteria={})
+
+
+async def test_get_db_map_for_prefix(mongodb: MongoDbFixture):
+    """Test get_db_map_for_prefix method on the docs dao."""
+    config = get_config(sources=[mongodb.config])
+
+    db_name1 = "db1"
+    db_name2 = "db2"
+    expected_db_map = {db_name1: ["test", "test2"], db_name2: ["test1"]}
+
+    async with DocsDao(config=config) as docs_dao:
+        # MongoDbFixture reset only empties collections, it doesn't delete them
+        # so we need to drop the databases manually to verify the functionality
+        for db in await docs_dao._client.list_database_names():
+            if db.startswith(config.db_prefix):
+                await docs_dao._client.drop_database(db)
+
+        # Insert documents to create the expected db_map
+        for db_name, colls in expected_db_map.items():
+            for coll in colls:
+                await docs_dao._client[f"{config.db_prefix}{db_name}"][coll].insert_one(
+                    {"key": "value"}
+                )
+
+        assert not await docs_dao.get_db_map_for_prefix(prefix="db")
+        assert not await docs_dao.get_db_map_for_prefix(prefix="")
+        db_map = await docs_dao.get_db_map_for_prefix(prefix=config.db_prefix)
+        assert db_map == expected_db_map

--- a/tests/unit/test_docs_dao.py
+++ b/tests/unit/test_docs_dao.py
@@ -108,3 +108,13 @@ async def test_get_db_map_for_prefix(mongodb: MongoDbFixture):
         assert not await docs_dao.get_db_map_for_prefix(prefix="")
         db_map = await docs_dao.get_db_map_for_prefix(prefix=config.db_prefix)
         assert db_map == expected_db_map
+
+        db1_map = await docs_dao.get_db_map_for_prefix(
+            prefix=config.db_prefix, db_name=db_name1
+        )
+
+        assert db1_map == {db_name1: ["test", "test2"]}
+
+        assert await docs_dao.get_db_map_for_prefix(
+            prefix=config.db_prefix, db_name="nonexistent"
+        ) == {"nonexistent": []}

--- a/tests/unit/test_docs_handler.py
+++ b/tests/unit/test_docs_handler.py
@@ -16,7 +16,7 @@
 """Test the DocDao class without any real"""
 
 from contextlib import nullcontext
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 from hexkit.providers.mongodb.testutils import MongoDbFixture
@@ -223,3 +223,40 @@ async def test_prefix_handling_wrt_permissions():
         upsertion_details=UpsertionDetails(documents=TEST_DOCS),
     )
     await docs_handler.delete(db_name=TEST_DB, collection=ALLOPS, criteria={})
+
+
+@pytest.mark.asyncio
+async def test_wildcard_deletion():
+    """Test deletion with wildcard arguments."""
+    docs_dao = AsyncMock(spec=DocsDaoPort)
+    docs_dao.delete = AsyncMock()
+    docs_dao.get_db_map_for_prefix.return_value = {
+        TEST_DB: [ALLOPS, READONLY, WRITEONLY],
+        "testdb2": [WRITEONLY],
+        "testdb3": [READONLY],
+    }
+    config = get_config()
+    docs_handler = DocsHandler(config=config, docs_dao=docs_dao)
+
+    # Test the invalid case of deleting a specific collection in all databases
+    with pytest.raises(ValueError):
+        await docs_handler.delete(db_name="*", collection=ALLOPS, criteria={})
+    docs_dao.delete.assert_not_awaited()
+    docs_dao.delete.reset_mock()
+
+    # Delete all collections in all databases that have write permissions
+    await docs_handler.delete(db_name="*", collection="*", criteria={})
+    assert docs_dao.delete.call_args_list == [
+        call(db_name=f"{config.db_prefix}{TEST_DB}", collection=ALLOPS, criteria={}),
+        call(db_name=f"{config.db_prefix}{TEST_DB}", collection=WRITEONLY, criteria={}),
+        call(db_name=f"{config.db_prefix}testdb2", collection=WRITEONLY, criteria={}),
+    ]
+
+    docs_dao.delete.reset_mock()
+
+    # Delete all collections in the testdb that have write permissions
+    await docs_handler.delete(db_name=TEST_DB, collection="*", criteria={})
+    assert docs_dao.delete.call_args_list == [
+        call(db_name=f"{config.db_prefix}{TEST_DB}", collection=ALLOPS, criteria={}),
+        call(db_name=f"{config.db_prefix}{TEST_DB}", collection=WRITEONLY, criteria={}),
+    ]

--- a/tests/unit/test_docs_handler.py
+++ b/tests/unit/test_docs_handler.py
@@ -230,11 +230,6 @@ async def test_wildcard_deletion():
     """Test deletion with wildcard arguments."""
     docs_dao = AsyncMock(spec=DocsDaoPort)
     docs_dao.delete = AsyncMock()
-    docs_dao.get_db_map_for_prefix.return_value = {
-        TEST_DB: [ALLOPS, READONLY, WRITEONLY],
-        "testdb2": [WRITEONLY],
-        "testdb3": [READONLY],
-    }
     config = get_config()
     docs_handler = DocsHandler(config=config, docs_dao=docs_dao)
 
@@ -245,6 +240,11 @@ async def test_wildcard_deletion():
     docs_dao.delete.reset_mock()
 
     # Delete all collections in all databases that have write permissions
+    docs_dao.get_db_map_for_prefix.return_value = {
+        TEST_DB: [ALLOPS, READONLY, WRITEONLY],
+        "testdb2": [WRITEONLY],
+        "testdb3": [READONLY],
+    }
     await docs_handler.delete(db_name="*", collection="*", criteria={})
     assert docs_dao.delete.call_args_list == [
         call(db_name=f"{config.db_prefix}{TEST_DB}", collection=ALLOPS, criteria={}),
@@ -255,6 +255,9 @@ async def test_wildcard_deletion():
     docs_dao.delete.reset_mock()
 
     # Delete all collections in the testdb that have write permissions
+    docs_dao.get_db_map_for_prefix.return_value = {
+        TEST_DB: [ALLOPS, READONLY, WRITEONLY],
+    }
     await docs_handler.delete(db_name=TEST_DB, collection="*", criteria={})
     assert docs_dao.delete.call_args_list == [
         call(db_name=f"{config.db_prefix}{TEST_DB}", collection=ALLOPS, criteria={}),


### PR DESCRIPTION
Adds the option to delete all documents from:
1. All collections in a given database, _or_
2. All collections in all databases

The deletion of documents from a given collection across all databases is prohibited (if you want to clear out all collections named `Users`, you should know where all collections named `Users` reside, and if not, you should not be issuing a mass deletion request). 

The deletion endpoint is not modified; both wildcard and fully targeted namespaces are accepted. For a wildcard deletion request, the following occurs:
1. All collections for all databases starting with `db_prefix` are retrieved. 
2. All call to `docs_dao.delete()` is made for each collection in the specified db or all dbs as appropriate
3. All occurrences of `PermissionError` are suppressed

If a fully targeted namespace is used, the deletion process is normal and permission errors are raised. 
It's important to note that the collections and databases _are not dropped_. Merely the documents within are deleted.