### PR TITLE
Allow empty prefix

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "1.0.0"
+version = "1.1.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`allow_empty_prefix`** *(boolean)*: Only set to True for local testing. If False, `db_prefix` cannot be empty. This is to prevent accidental deletion of others' data in shared environments, i.e. staging. Default: `false`.
+
+
+  Examples:
+
+  ```json
+  true
+  ```
+
+
+  ```json
+  false
+  ```
+
+
 - **`db_permissions`** *(array)*: List of permissions that can be granted on a collection. Use * to signify 'all'. The format is '<db_name>.<collection_name>:<permissions>', e.g. 'db1.collection1.crud'. The permissions are 'r' for read and 'w' for write. '*' can be used to mean both read and write (or 'rw'). Deletion is a write operation. If db_permissions are not set, no operations are allowed on any database or collection. Default: `[]`.
 
   - **Items** *(string)*

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:1.0.0
+docker pull ghga/state-management-service:1.1.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:1.0.0 .
+docker build -t ghga/state-management-service:1.1.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:1.0.0 --help
+docker run -p 8080:8080 ghga/state-management-service:1.1.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/config_schema.json
+++ b/config_schema.json
@@ -21,6 +21,16 @@
       "title": "Db Prefix",
       "type": "string"
     },
+    "allow_empty_prefix": {
+      "default": false,
+      "description": "Only set to True for local testing. If False, `db_prefix` cannot be empty. This is to prevent accidental deletion of others' data in shared environments, i.e. staging.",
+      "examples": [
+        true,
+        false
+      ],
+      "title": "Allow Empty Prefix",
+      "type": "boolean"
+    },
     "db_permissions": {
       "default": [],
       "description": "List of permissions that can be granted on a collection. Use * to signify 'all'. The format is '<db_name>.<collection_name>:<permissions>', e.g. 'db1.collection1.crud'. The permissions are 'r' for read and 'w' for write. '*' can be used to mean both read and write (or 'rw'). Deletion is a write operation. If db_permissions are not set, no operations are allowed on any database or collection.",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,4 @@
+allow_empty_prefix: false
 api_root_path: ''
 auto_reload: false
 cors_allow_credentials: null

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 1.0.0
+  version: 1.1.0
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "1.0.0"
+version = "1.1.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/src/sms/adapters/outbound/docs_dao.py
+++ b/src/sms/adapters/outbound/docs_dao.py
@@ -102,9 +102,6 @@ class DocsDao(DocsDaoPort):
         empty. If `db_name` is provided but no collections exist, an empty list is
         returned with the database name as the key.
         """
-        if not prefix:
-            return {}
-
         if db_name:
             full_db_name = f"{prefix}{db_name}"
             return {
@@ -118,5 +115,5 @@ class DocsDao(DocsDaoPort):
                 await self._client[db].list_collection_names()
             )
             for db in await self._client.list_database_names()
-            if db.startswith(prefix)
+            if db.startswith(prefix) and db not in ("admin", "config", "local")
         }

--- a/src/sms/adapters/outbound/docs_dao.py
+++ b/src/sms/adapters/outbound/docs_dao.py
@@ -20,6 +20,8 @@ from sms.config import Config
 from sms.models import Criteria, DocumentType
 from sms.ports.outbound.docs_dao import DocsDaoPort
 
+DEFAULT_DBS: tuple[str, str, str] = ("admin", "config", "local")
+
 
 class DocsDao(DocsDaoPort):
     """A class to perform CRUD operations in MongoDB."""
@@ -115,5 +117,5 @@ class DocsDao(DocsDaoPort):
                 await self._client[db].list_collection_names()
             )
             for db in await self._client.list_database_names()
-            if db.startswith(prefix) and db not in ("admin", "config", "local")
+            if db.startswith(prefix) and db not in DEFAULT_DBS
         }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,55 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Config-related tests."""
+
+import pytest
+from pydantic import SecretStr
+
+from sms.config import Config
+
+
+def test_prefix_config():
+    """Make sure you can't accidentally configure an empty prefix."""
+    with pytest.raises(ValueError):
+        Config(
+            token_hashes=[],
+            db_connection_str=SecretStr(""),
+            db_prefix="",
+            service_instance_id="1",
+        )
+
+    Config(
+        token_hashes=[],
+        db_connection_str=SecretStr(""),
+        db_prefix="",
+        allow_empty_prefix=True,
+        service_instance_id="1",
+    )
+
+    Config(
+        token_hashes=[],
+        db_connection_str=SecretStr(""),
+        db_prefix="test",
+        allow_empty_prefix=True,
+        service_instance_id="1",
+    )
+
+    Config(
+        token_hashes=[],
+        db_connection_str=SecretStr(""),
+        db_prefix="test",
+        allow_empty_prefix=False,
+        service_instance_id="1",
+    )

--- a/tests/unit/test_docs_dao.py
+++ b/tests/unit/test_docs_dao.py
@@ -17,7 +17,7 @@
 import pytest
 from hexkit.providers.mongodb.testutils import MongoDbFixture
 
-from sms.adapters.outbound.docs_dao import DocsDao
+from sms.adapters.outbound.docs_dao import DEFAULT_DBS, DocsDao
 from sms.models import DocumentType
 from tests.fixtures.config import get_config
 
@@ -112,7 +112,7 @@ async def test_get_db_map_for_prefix(
         # MongoDbFixture reset only empties collections, it doesn't delete them
         # so we need to drop the databases manually to verify the functionality
         for db in await docs_dao._client.list_database_names():
-            if db not in ("admin", "config", "local"):
+            if db not in DEFAULT_DBS:
                 await docs_dao._client.drop_database(db)
 
         # Insert documents to create the expected db_map


### PR DESCRIPTION
An empty `db_prefix` is valid config, but it should only be set that way with intent. To prevent it from being forgotten or set that way carelessly in staging and allowing mass deletions, a new parameter `allow_empty_prefix` is configurable with a default of `False`. A `ValueError` will be raised if `db_prefix` is blank and `allow_empty_prefix` is not set to `True`. 
This change will simplify (enable?) local testing.