### PR TITLE
Use SSL

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "1.3.0"
+version = "1.3.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:1.3.0
+docker pull ghga/state-management-service:1.3.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:1.3.0 .
+docker build -t ghga/state-management-service:1.3.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:1.3.0 --help
+docker run -p 8080:8080 ghga/state-management-service:1.3.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 1.3.0
+  version: 1.3.1
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "1.3.0"
+version = "1.3.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/src/sms/core/events_handler.py
+++ b/src/sms/core/events_handler.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager
 
 from aiokafka import TopicPartition
 from aiokafka.admin import AIOKafkaAdminClient, RecordsToDelete
+from hexkit.providers.akafka.provider.utils import generate_ssl_context
 
 from sms.config import Config
 from sms.ports.inbound.events_handler import EventsHandlerPort
@@ -33,7 +34,11 @@ class EventsHandler(EventsHandlerPort):
     @asynccontextmanager
     async def get_admin_client(self) -> AsyncGenerator[AIOKafkaAdminClient, None]:
         """Construct and return an instance of AIOKafkaAdminClient that is closed after use."""
-        admin_client = AIOKafkaAdminClient(bootstrap_servers=self._config.kafka_servers)
+        admin_client = AIOKafkaAdminClient(
+            bootstrap_servers=self._config.kafka_servers,
+            security_protocol=self._config.kafka_security_protocol,
+            ssl_context=generate_ssl_context(self._config),
+        )
         await admin_client.start()
         try:
             yield admin_client


### PR DESCRIPTION
The kafka admin client class wasn't being instantiated with the SSL parameters, causing failures when it was actually used. This was not caught because the parameters are not needed in a local test setup.

patch version number is bumped