### PR TITLE
Configurable vault mount point (GSI-1130)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -4,6 +4,7 @@ token_hashes:
 - 7ad83b6b9183c91674eec897935bc154ba9ff9704f8be0840e77f476b5062b6e
 vault_token: "dev-token"
 vault_url: "http://vault:8200"
+vault_secrets_mount_point: secret
 
 db_connection_str: mongodb://mongodb:27017
 db_prefix: "test_"

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "1.4.0"
+version = "1.4.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ The service requires the following configuration parameters:
   ```
 
 
+- **`vault_secrets_mount_point`** *(string)*: Name used to address the secret engine under a custom mount path. Default: `"secret"`.
+
+
+  Examples:
+
+  ```json
+  "secret"
+  ```
+
+
 - **`token_hashes`** *(array, required)*: List of token hashes corresponding to the tokens that can be used to authenticate calls to this service. Hashes are made with SHA-256.
 
   - **Items** *(string)*

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:1.4.0
+docker pull ghga/state-management-service:1.4.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:1.4.0 .
+docker build -t ghga/state-management-service:1.4.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:1.4.0 --help
+docker run -p 8080:8080 ghga/state-management-service:1.4.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/config_schema.json
+++ b/config_schema.json
@@ -204,6 +204,15 @@
       "title": "Vault Token",
       "type": "string"
     },
+    "vault_secrets_mount_point": {
+      "default": "secret",
+      "description": "Name used to address the secret engine under a custom mount path.",
+      "examples": [
+        "secret"
+      ],
+      "title": "Vault Secrets Mount Point",
+      "type": "string"
+    },
     "token_hashes": {
       "description": "List of token hashes corresponding to the tokens that can be used to authenticate calls to this service. Hashes are made with SHA-256.",
       "examples": [

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -46,6 +46,7 @@ service_instance_id: '1'
 service_name: sms
 token_hashes:
 - 7ad83b6b9183c91674eec897935bc154ba9ff9704f8be0840e77f476b5062b6e
+vault_secrets_mount_point: secret
 vault_token: dev-token
 vault_url: http://vault:8200
 workers: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 1.4.0
+  version: 1.4.1
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "1.4.0"
+version = "1.4.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/tests/unit/secrets/test_secrets_handler.py
+++ b/tests/unit/secrets/test_secrets_handler.py
@@ -107,7 +107,8 @@ def test_delete_successful(
 
     # delete_metadata_and_all_versions is called for each secret
     internal_deletion_calls = [
-        call(path=f"{DEFAULT_VAULT_PATH}/{secret}") for secret in stored_secrets
+        call(path=f"{DEFAULT_VAULT_PATH}/{secret}", mount_point="secret")
+        for secret in stored_secrets
     ]
     mock_client.secrets.kv.v2.delete_metadata_and_all_versions.assert_has_calls(
         internal_deletion_calls,


### PR DESCRIPTION
Made the vault mount point configurable. We only have the ekss for now, but this will let us use non-default mount points in the ekss and test with sms. We can add the ability to specify mount points in the REST API later if we ever need to.

bumps the version from `1.4.0` to `1.4.1`.