### PR TITLE
Fix vault auth (GSI-1185)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -2,7 +2,6 @@ service_instance_id: "1"
 token_hashes:
 # plaintext token: 43fadc91-b98f-4925-bd31-1b054b13dc55
 - 7ad83b6b9183c91674eec897935bc154ba9ff9704f8be0840e77f476b5062b6e
-vault_token: "dev-token"
 vault_url: "http://vault:8200"
 vault_secrets_mount_point: secret
 vault_path: sms

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "2.0.0"
+version = "3.0.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:2.0.0
+docker pull ghga/state-management-service:3.0.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:2.0.0 .
+docker build -t ghga/state-management-service:3.0.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:2.0.0 --help
+docker run -p 8080:8080 ghga/state-management-service:3.0.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -132,16 +132,6 @@ The service requires the following configuration parameters:
 
   ```json
   "http://vault:8200"
-  ```
-
-
-- **`vault_token`** *(string, required)*: Token for the Vault.
-
-
-  Examples:
-
-  ```json
-  "dev-token"
   ```
 
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -196,14 +196,6 @@
       "title": "Vault Url",
       "type": "string"
     },
-    "vault_token": {
-      "description": "Token for the Vault",
-      "examples": [
-        "dev-token"
-      ],
-      "title": "Vault Token",
-      "type": "string"
-    },
     "vault_secrets_mount_point": {
       "default": "secret",
       "description": "Name used to address the secret engine under a custom mount path.",
@@ -535,7 +527,6 @@
     "kafka_servers",
     "object_storages",
     "vault_url",
-    "vault_token",
     "vault_path",
     "token_hashes",
     "db_prefix",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -53,7 +53,6 @@ vault_path: sms
 vault_role_id: '**********'
 vault_secret_id: '**********'
 vault_secrets_mount_point: secret
-vault_token: dev-token
 vault_url: http://vault:8200
 vault_verify: true
 workers: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,7 +57,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 2.0.0
+  version: 3.0.0
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "2.0.0"
+version = "3.0.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/src/sms/adapters/inbound/fastapi_/routers/secrets.py
+++ b/src/sms/adapters/inbound/fastapi_/routers/secrets.py
@@ -48,6 +48,10 @@ async def get_secrets(
     """Returns a list of secrets in the specified vault"""
     try:
         return secrets_handler.get_secrets(vault_path)
+    except PermissionError as err:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(err)
+        ) from err
     except Exception as exc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) from exc
 
@@ -66,5 +70,9 @@ async def delete_secrets(
     """Delete all secrets from the specified vault."""
     try:
         secrets_handler.delete_secrets(vault_path)
+    except PermissionError as err:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail=str(err)
+        ) from err
     except Exception as exc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) from exc

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -2,7 +2,6 @@ service_instance_id: "1"
 token_hashes:
 # plaintext token: 43fadc91-b98f-4925-bd31-1b054b13dc55
 - 7ad83b6b9183c91674eec897935bc154ba9ff9704f8be0840e77f476b5062b6e
-vault_token: "dev-token"
 vault_url: "http://vault:8200"
 vault_path: sms
 vault_role_id: dummy-role

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -94,8 +94,13 @@ async def test_nonexistent_vault_path(vault: VaultFixture):
         AsyncTestClient(app=app) as client,
     ):
         response = await client.get("/secrets/doesnotexist", headers=HEADERS)
-        assert response.status_code == 200
-        assert response.json() == []
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": "Permission not configured for vault path 'doesnotexist'"
+        }
 
         response = await client.delete("/secrets/doesnotexist", headers=HEADERS)
-        assert response.status_code == 204
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": "Permission not configured for vault path 'doesnotexist'"
+        }


### PR DESCRIPTION
Deleted the `vault_token` config parameter.

The HVAC client was previously defined as a property on the `SecretsHandler` class, but now it's just a regular attribute. That was responsible for at least part of the permission issues, but not sure if that was everything.

HVAC raises a "Forbidden" error type if you try to access a vault path that is not enabled (either the permission used isn't in the policy or the entire vault path is blocked), so those are returned as 403 errors in the API.

The vault test fixture needed to have the login functionality too, so that was added.

The validation function for `vault_verify` was in the wrong spot -- now it's part of the config like it should be.

The changes in `tests/unit/secrets/test_secrets_handler.py` are to remove the MonkeyPatch fixture.