### PR TITLE
Clear compacted topics (GSI-1539)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--check]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, dev, --branch, int, --branch, main]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -5,7 +5,7 @@ description = "State Management Service - Provides a REST API for basic infrastr
 dependencies = [
     "typer >= 0.12",
     "ghga-service-commons[api] >= 3.3",
-    "hexkit[mongodb,s3,akafka] >= 4.0",
+    "hexkit[mongodb,s3,akafka] >= 4.5",
     "hvac>=2",
 ]
 

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "4.0.0"
+version = "4.0.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:4.0.0
+docker pull ghga/state-management-service:4.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:4.0.0 .
+docker build -t ghga/state-management-service:4.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:4.0.0 --help
+docker run -p 8080:8080 ghga/state-management-service:4.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -52,13 +52,13 @@ attrs==25.3.0 \
     # via
     #   jsonschema
     #   referencing
-boto3==1.37.31 \
-    --hash=sha256:cf8997be0742a5cab9d33a138ef56e423a8ebd8881f6f73e95076b26656b36dc \
-    --hash=sha256:dfee02b2f8f632a239a2f4ba6a2d568e2edd7f7464e9afd8a487fdb3fa9a0ad3
+boto3==1.37.34 \
+    --hash=sha256:586bfa72a00601c04067f9adcbb08ecaf63b05b7d731103f33cb2ce0d6950b1b \
+    --hash=sha256:94ca07328474db3fa605eb99b011512caa73f7161740d365a1f00cfebfb6dd90
     # via hexkit
-botocore==1.37.31 \
-    --hash=sha256:598a33a7a0e5a014bd1416c999a0b9c634fbbba3d1363e2368e6a92da4544df4 \
-    --hash=sha256:eb3dfa44a87187bd82c3b493d568d8436270d4d000f237b49b669a01fcd8a21c
+botocore==1.37.34 \
+    --hash=sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac \
+    --hash=sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a
     # via
     #   boto3
     #   hexkit
@@ -278,15 +278,15 @@ h11==0.14.0 \
     # via
     #   httpcore
     #   uvicorn
-hexkit==4.3.1 \
-    --hash=sha256:b1f608978940d2e10bc476fb121eac0cc86bd3cd080061216fb748ce122d1a84 \
-    --hash=sha256:edda094e24978b54d9629d0fbe963a885e48bb6cbc59f15d86749e68a6288634
+hexkit==4.5.0 \
+    --hash=sha256:a6aef02e1284e5acae01ba9f8b885e2e97ca85644df392e622029f99ce360ec6 \
+    --hash=sha256:e91b89f051cc3111fc4038ccb14de9215d4c1d462c889237450296fc82205d01
     # via
     #   sms (pyproject.toml)
     #   ghga-service-commons
-httpcore==1.0.7 \
-    --hash=sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c \
-    --hash=sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd
+httpcore==1.0.8 \
+    --hash=sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be \
+    --hash=sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad
     # via httpx
 httptools==0.6.4 \
     --hash=sha256:0614154d5454c21b6410fdf5262b4a3ddb0f53f1e1721cfd59d55f32138c578a \
@@ -445,9 +445,9 @@ nodeenv==1.9.1 \
     --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
     --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
     # via pre-commit
-opentelemetry-api==1.31.1 \
-    --hash=sha256:137ad4b64215f02b3000a0292e077641c8611aab636414632a9b9068593b7e91 \
-    --hash=sha256:1511a3f470c9c8a32eeea68d4ea37835880c0eed09dd1a0187acc8b1301da0a1
+opentelemetry-api==1.32.1 \
+    --hash=sha256:a5be71591694a4d9195caf6776b055aa702e964d961051a0715d05f8632c32fb \
+    --hash=sha256:bbd19f14ab9f15f0e85e43e6a958aa4cb1f36870ee62b7fd205783a112012724
     # via hexkit
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
@@ -868,25 +868,25 @@ rpds-py==0.24.0 \
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.4 \
-    --hash=sha256:0e9365a7dff9b93af933dab8aebce53b72d8f815e131796268709890b4a83270 \
-    --hash=sha256:126b1bf13154aa18ae2d6c3c5efe144ec14b97c60844cfa6eb960c2a05188222 \
-    --hash=sha256:193e6fac6eb60cc97b9f728e953c21cc38a20077ed64f912e9d62b97487f3f2d \
-    --hash=sha256:3f171605f65f4fc49c87f41b456e882cd0c89e4ac9d58e149a2b07930e1d466f \
-    --hash=sha256:51a6494209cacca79e121e9b244dc30d3414dac8cc5afb93f852173a2ecfc906 \
-    --hash=sha256:5a9fa1c69c7815e39fcfb3646bbfd7f528fa8e2d4bebdcf4c2bd0fa037a255fb \
-    --hash=sha256:5d94bb1cc2fc94a769b0eb975344f1b1f3d294da1da9ddbb5a77665feb3a3019 \
-    --hash=sha256:7a37ca937e307ea18156e775a6ac6e02f34b99e8c23fe63c1996185a4efe0751 \
-    --hash=sha256:7af4e5f69b7c138be8dcffa5b4a061bf6ba6a3301f632a6bce25d45daff9bc99 \
-    --hash=sha256:8c1747d903447d45ca3d40c794d1a56458c51e5cc1bc77b7b64bd2cf0b1626cc \
-    --hash=sha256:995071203d0fe2183fc7a268766fd7603afb9996785f086b0d76edee8755c896 \
-    --hash=sha256:d435db6b9b93d02934cf61ef332e66af82da6d8c69aefdea5994c89997c7a0fc \
-    --hash=sha256:d9f4a761ecbde448a2d3e12fb398647c7f0bf526dbc354a643ec505965824ed2 \
-    --hash=sha256:e8806daaf9dfa881a0ed603f8a0e364e4f11b6ed461b56cae2b1c0cab0645304 \
-    --hash=sha256:ebf99ea9af918878e6ce42098981fc8c1db3850fef2f1ada69fb1dcdb0f8e79e \
-    --hash=sha256:edad2eac42279df12e176564a23fc6f4aaeeb09abba840627780b1bb11a9d223 \
-    --hash=sha256:f103a848be9ff379fc19b5d656c1f911d0a0b4e3e0424f9532ececf319a4296e \
-    --hash=sha256:f45bd2fb1a56a5a85fae3b95add03fb185a0b30cf47f5edc92aa0355ca1d7407
+ruff==0.11.5 \
+    --hash=sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794 \
+    --hash=sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b \
+    --hash=sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a \
+    --hash=sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779 \
+    --hash=sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82 \
+    --hash=sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e \
+    --hash=sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800 \
+    --hash=sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470 \
+    --hash=sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783 \
+    --hash=sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077 \
+    --hash=sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038 \
+    --hash=sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159 \
+    --hash=sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef \
+    --hash=sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe \
+    --hash=sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304 \
+    --hash=sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f \
+    --hash=sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a \
+    --hash=sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b
     # via -r lock/requirements-dev-template.in
 s3transfer==0.11.4 \
     --hash=sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679 \
@@ -912,9 +912,9 @@ sniffio==1.3.1 \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
     # via anyio
-starlette==0.46.1 \
-    --hash=sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230 \
-    --hash=sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227
+starlette==0.46.2 \
+    --hash=sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35 \
+    --hash=sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
     # via fastapi
 testcontainers==4.10.0 \
     --hash=sha256:03f85c3e505d8b4edeb192c72a961cebbcba0dd94344ae778b4a159cb6dcf8d3 \
@@ -943,9 +943,9 @@ typer==0.15.2 \
     # via
     #   -r lock/requirements-dev-template.in
     #   sms (pyproject.toml)
-typing-extensions==4.13.1 \
-    --hash=sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69 \
-    --hash=sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff
+typing-extensions==4.13.2 \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
+    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via
     #   aiokafka
     #   anyio
@@ -961,9 +961,9 @@ typing-inspection==0.4.0 \
     --hash=sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f \
     --hash=sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122
     # via pydantic
-urllib3==2.3.0 \
-    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
-    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+urllib3==2.4.0 \
+    --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
+    --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
     # via
     #   -r lock/requirements-dev-template.in
     #   botocore
@@ -990,9 +990,9 @@ uv==0.6.14 \
     --hash=sha256:ed41877b679e0a1af9ab65427d829b87a81b499017e59c70756d4ba02ca43fcb \
     --hash=sha256:fe9b4361b1c8055301b715fdd94d94eb512053dc4545fec40d3fe3657f655987
     # via -r lock/requirements-dev-template.in
-uvicorn==0.34.0 \
-    --hash=sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4 \
-    --hash=sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9
+uvicorn==0.34.1 \
+    --hash=sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065 \
+    --hash=sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc
     # via ghga-service-commons
 uvloop==0.21.0 \
     --hash=sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0 \

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -60,15 +60,15 @@ attrs==25.3.0 \
     #   -c lock/requirements-dev.txt
     #   jsonschema
     #   referencing
-boto3==1.37.31 \
-    --hash=sha256:cf8997be0742a5cab9d33a138ef56e423a8ebd8881f6f73e95076b26656b36dc \
-    --hash=sha256:dfee02b2f8f632a239a2f4ba6a2d568e2edd7f7464e9afd8a487fdb3fa9a0ad3
+boto3==1.37.34 \
+    --hash=sha256:586bfa72a00601c04067f9adcbb08ecaf63b05b7d731103f33cb2ce0d6950b1b \
+    --hash=sha256:94ca07328474db3fa605eb99b011512caa73f7161740d365a1f00cfebfb6dd90
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit
-botocore==1.37.31 \
-    --hash=sha256:598a33a7a0e5a014bd1416c999a0b9c634fbbba3d1363e2368e6a92da4544df4 \
-    --hash=sha256:eb3dfa44a87187bd82c3b493d568d8436270d4d000f237b49b669a01fcd8a21c
+botocore==1.37.34 \
+    --hash=sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac \
+    --hash=sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a
     # via
     #   -c lock/requirements-dev.txt
     #   boto3
@@ -216,16 +216,16 @@ h11==0.14.0 \
     #   -c lock/requirements-dev.txt
     #   httpcore
     #   uvicorn
-hexkit==4.3.1 \
-    --hash=sha256:b1f608978940d2e10bc476fb121eac0cc86bd3cd080061216fb748ce122d1a84 \
-    --hash=sha256:edda094e24978b54d9629d0fbe963a885e48bb6cbc59f15d86749e68a6288634
+hexkit==4.5.0 \
+    --hash=sha256:a6aef02e1284e5acae01ba9f8b885e2e97ca85644df392e622029f99ce360ec6 \
+    --hash=sha256:e91b89f051cc3111fc4038ccb14de9215d4c1d462c889237450296fc82205d01
     # via
     #   -c lock/requirements-dev.txt
     #   sms (pyproject.toml)
     #   ghga-service-commons
-httpcore==1.0.7 \
-    --hash=sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c \
-    --hash=sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd
+httpcore==1.0.8 \
+    --hash=sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be \
+    --hash=sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad
     # via
     #   -c lock/requirements-dev.txt
     #   httpx
@@ -339,9 +339,9 @@ motor==3.7.0 \
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit
-opentelemetry-api==1.31.1 \
-    --hash=sha256:137ad4b64215f02b3000a0292e077641c8611aab636414632a9b9068593b7e91 \
-    --hash=sha256:1511a3f470c9c8a32eeea68d4ea37835880c0eed09dd1a0187acc8b1301da0a1
+opentelemetry-api==1.32.1 \
+    --hash=sha256:a5be71591694a4d9195caf6776b055aa702e964d961051a0715d05f8632c32fb \
+    --hash=sha256:bbd19f14ab9f15f0e85e43e6a958aa4cb1f36870ee62b7fd205783a112012724
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit
@@ -769,9 +769,9 @@ sniffio==1.3.1 \
     # via
     #   -c lock/requirements-dev.txt
     #   anyio
-starlette==0.46.1 \
-    --hash=sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230 \
-    --hash=sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227
+starlette==0.46.2 \
+    --hash=sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35 \
+    --hash=sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
     # via
     #   -c lock/requirements-dev.txt
     #   fastapi
@@ -781,9 +781,9 @@ typer==0.15.2 \
     # via
     #   -c lock/requirements-dev.txt
     #   sms (pyproject.toml)
-typing-extensions==4.13.1 \
-    --hash=sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69 \
-    --hash=sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff
+typing-extensions==4.13.2 \
+    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
+    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via
     #   -c lock/requirements-dev.txt
     #   aiokafka
@@ -800,16 +800,16 @@ typing-inspection==0.4.0 \
     # via
     #   -c lock/requirements-dev.txt
     #   pydantic
-urllib3==2.3.0 \
-    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
-    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+urllib3==2.4.0 \
+    --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
+    --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
     # via
     #   -c lock/requirements-dev.txt
     #   botocore
     #   requests
-uvicorn==0.34.0 \
-    --hash=sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4 \
-    --hash=sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9
+uvicorn==0.34.1 \
+    --hash=sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065 \
+    --hash=sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,7 +95,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 4.0.0
+  version: 4.0.1
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "4.0.0"
+version = "4.0.1"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ description = "State Management Service - Provides a REST API for basic infrastr
 dependencies = [
     "typer >= 0.12",
     "ghga-service-commons[api] >= 3.3",
-    "hexkit[mongodb,s3,akafka] >= 4.0",
+    "hexkit[mongodb,s3,akafka] >= 4.5",
     "hvac>=2",
 ]
 

--- a/src/sms/core/events_handler.py
+++ b/src/sms/core/events_handler.py
@@ -22,7 +22,6 @@ from aiokafka import TopicPartition
 from aiokafka.admin import AIOKafkaAdminClient, RecordsToDelete
 from aiokafka.admin.config_resource import ConfigResource, ConfigResourceType
 from hexkit.protocols.eventpub import EventPublisherProtocol
-from hexkit.providers.akafka.provider.utils import generate_ssl_context
 
 from sms.config import Config
 from sms.models import EventDetails

--- a/src/sms/core/events_handler.py
+++ b/src/sms/core/events_handler.py
@@ -162,8 +162,7 @@ class EventsHandler(EventsHandlerPort):
                     # Always set compacted topics back to their original policy
                     if original_policy:
                         await self._set_cleanup_policy(
-                            topic=topic,  # type: ignore
-                            policy=original_policy,
+                            topic=topic, policy=original_policy
                         )
 
     async def publish_event(self, *, event_details: EventDetails):

--- a/src/sms/core/events_handler.py
+++ b/src/sms/core/events_handler.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 """Contains implementation of the EventsHandler class."""
 
-from collections.abc import AsyncGenerator
+import asyncio
 from contextlib import asynccontextmanager
+from typing import Any
 
 from aiokafka import TopicPartition
 from aiokafka.admin import AIOKafkaAdminClient, RecordsToDelete
@@ -34,52 +35,83 @@ class EventsHandler(EventsHandlerPort):
     def __init__(self, *, config: Config, event_publisher: EventPublisherProtocol):
         self._config = config
         self._event_publisher = event_publisher
+        self._admin_client: AIOKafkaAdminClient | None = None
 
     @asynccontextmanager
-    async def get_admin_client(self) -> AsyncGenerator[AIOKafkaAdminClient, None]:
-        """Construct and return an instance of AIOKafkaAdminClient that is closed after use."""
-        admin_client = AIOKafkaAdminClient(
-            bootstrap_servers=self._config.kafka_servers,
-            security_protocol=self._config.kafka_security_protocol,
-            ssl_context=generate_ssl_context(self._config),
+    async def get_admin_client(self):
+        """An async context manager that provides a running AIOKafkaAdminClient
+        as a singleton instance.
+
+        If a running client already exists, it is yielded directly.
+        If not, this is considered the root use of the CM, so we start a new client,
+        yield it, then close the client within a `finally` block.
+        """
+        if self._admin_client:
+            yield self._admin_client
+            return
+
+        # No running client exists, so create one and make sure to clean up afterward.
+        self._admin_client = AIOKafkaAdminClient(
+            bootstrap_servers=self._config.kafka_servers
         )
-        await admin_client.start()
+        await self._admin_client.start()
         try:
-            yield admin_client
+            yield self._admin_client
         finally:
-            await admin_client.close()
+            await self._admin_client.close()
+            self._admin_client = None
 
-    async def _get_cleanup_policy(
-        self, *, admin_client: AIOKafkaAdminClient, topic: str
-    ) -> str | None:
+    async def _get_cleanup_policy(self, *, topic: str) -> str | None:
         """Get the current cleanup policy for a topic or None if the topic doesn't exist"""
-        config_response = await admin_client.describe_configs(
-            [ConfigResource(ConfigResourceType.TOPIC, name=topic)]
-        )
-        config_resources = config_response[0].resources[0]
-        configs = config_resources[-1]
-        policy = None
-        for item in configs:
-            if item[0] == "cleanup.policy":
-                policy = item[1]
-                break
-        return policy
+        return await self._get_topic_config(topic=topic, config_name="cleanup.policy")
 
-    async def _set_cleanup_policy(
-        self, *, admin_client: AIOKafkaAdminClient, topic: str, policy: str
-    ):
-        """Set the cleanup policy"""
-        await admin_client.alter_configs(
-            config_resources=[
-                ConfigResource(
-                    ConfigResourceType.TOPIC,
-                    name=topic,
-                    configs={
-                        "cleanup.policy": policy,
-                    },
-                )
-            ]
-        )
+    async def _get_topic_config(self, *, topic: str, config_name: str) -> str | None:
+        """Get the current config for a topic or None if the topic/config doesn't exist"""
+        async with self.get_admin_client() as admin_client:
+            # fetch a list containing a response for each requested topic
+            config_list = await admin_client.describe_configs(
+                [ConfigResource(ConfigResourceType.TOPIC, name=topic)]
+            )
+
+        # We only requested one topic, so get the first/only element from the list
+        config_response = config_list[0]
+
+        # Each config response has a 'resources' attribute
+        resources = config_response.resources
+
+        # The resources attr is a list containing one tuple for each requested topic.
+        #  We only requested one topic, so our target is the first element.
+        requested_resource = resources[0]
+
+        # The resource itself is a list, and the topic config is at the end
+        configs = requested_resource[-1]
+        value = None
+        config_name = config_name.lower()
+
+        # The `configs` item is a list of tuples, where each tuple is a config item
+        # The first item is the config name, the second is the value, and the rest are ancillary
+        for item in configs:
+            if item[0].lower() == config_name:
+                value = item[1]
+                break
+        return value
+
+    async def _set_cleanup_policy(self, *, topic: str, policy: str):
+        """Set the cleanup policy for the given topic. The topic must already exist."""
+        await self._set_topic_config(topic=topic, config={"cleanup.policy": policy})
+
+    async def _set_topic_config(self, *, topic: str, config: dict[str, Any]):
+        """Set an arbitrary config value(s) for a topic"""
+        async with self.get_admin_client() as admin_client:
+            await admin_client.alter_configs(
+                config_resources=[
+                    ConfigResource(
+                        ConfigResourceType.TOPIC,
+                        name=topic,
+                        configs=config,
+                    )
+                ]
+            )
 
     async def clear_topics(self, *, topics: list[str], exclude_internal: bool = True):
         """Clear messages from given topic(s).
@@ -92,42 +124,47 @@ class EventsHandler(EventsHandlerPort):
         its original value (either 'compact' or 'compact,delete').
         """
         async with self.get_admin_client() as admin_client:
+            available_topics = await admin_client.list_topics()
             if not topics:
-                topics = await admin_client.list_topics()
+                topics = available_topics
+            elif isinstance(topics, str):
+                topics = [topics]
             if exclude_internal:
                 topics = [topic for topic in topics if not topic.startswith("__")]
 
-            # Record the current cleanup policies before modifying them
-            original_policies = {}
-            for topic in topics:
-                policy = await self._get_cleanup_policy(
-                    admin_client=admin_client, topic=topic
-                )
-                if policy and "compact" in policy.split(","):
-                    original_policies[topic] = policy
-                    await self._set_cleanup_policy(
-                        admin_client=admin_client, topic=topic, policy="delete"
-                    )
+            # Filter out any topics that don't exist
+            topics = [topic for topic in topics if topic in available_topics]
+            if not topics:
+                return
 
-            # Create `RecordsToDelete` object for each topic we want to clear
+            # Record the current cleanup policies before modifying them
             topics_info = await admin_client.describe_topics(topics)
-            records_to_delete = {
-                TopicPartition(
-                    topic=topic_info["topic"], partition=partition_info["partition"]
-                ): RecordsToDelete(before_offset=-1)
-                for topic_info in topics_info
-                for partition_info in topic_info["partitions"]
-            }
-            try:
-                # Perform the delete, ensuring the cleanup policy is always restored
-                await admin_client.delete_records(records_to_delete, timeout_ms=10000)
-            finally:
-                for topic, policy in original_policies.items():
-                    await self._set_cleanup_policy(
-                        admin_client=admin_client,
-                        topic=topic,
-                        policy=policy,
+            for topic_info in topics_info:
+                topic = topic_info["topic"]
+                original_policy = await self._get_cleanup_policy(topic=topic)
+                if original_policy and "compact" in original_policy.split(","):
+                    await self._set_cleanup_policy(topic=topic, policy="delete")
+                    await asyncio.sleep(0.2)  # brief pause to wait for policy changes
+
+                records_to_delete = {
+                    TopicPartition(
+                        topic=topic, partition=partition_info["partition"]
+                    ): RecordsToDelete(before_offset=-1)
+                    for partition_info in topic_info["partitions"]
+                }
+
+                # Delete any events in the topic
+                try:
+                    await admin_client.delete_records(
+                        records_to_delete, timeout_ms=10000
                     )
+                finally:
+                    # Always set compacted topics back to their original policy
+                    if original_policy:
+                        await self._set_cleanup_policy(
+                            topic=topic,  # type: ignore
+                            policy=original_policy,
+                        )
 
     async def publish_event(self, *, event_details: EventDetails):
         """Publish a single event to the given topic.

--- a/src/sms/core/events_handler.py
+++ b/src/sms/core/events_handler.py
@@ -144,6 +144,8 @@ class EventsHandler(EventsHandlerPort):
                 if original_policy and "compact" in original_policy.split(","):
                     await self._set_cleanup_policy(topic=topic, policy="delete")
                     await asyncio.sleep(0.2)  # brief pause to wait for policy changes
+                else:
+                    original_policy = None  # don't need to revert 'delete' topics
 
                 records_to_delete = {
                     TopicPartition(

--- a/src/sms/ports/inbound/events_handler.py
+++ b/src/sms/ports/inbound/events_handler.py
@@ -39,6 +39,10 @@ class EventsHandlerPort(ABC):
 
         If no topics are specified, all topics will be cleared, except internal topics
         unless otherwise specified.
+
+        To enable topic clearing for compacted topics, the cleanup policy is temporarily
+        set to 'delete' while the action is performed. Afterward, the policy is set to
+        its original value (either 'compact' or 'compact,delete').
         """
         ...
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -93,6 +93,8 @@ async def test_get_policy(kafka: KafkaFixture):
             # Verify that the returned value is correct
             assert assigned_policy == policy
 
+        await admin_client.delete_topics([item[0] for item in topic_policies])
+
 
 async def test_set_policy(kafka: KafkaFixture):
     """Verify that `_set_cleanup_policy()` updates the current value"""

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -58,7 +58,7 @@ TEST_TOPICS = [TEST_TOPIC1, TEST_TOPIC2]
 async def test_get_policy(kafka: KafkaFixture):
     """Verify that `_get_cleanup_policy()` returns the current value"""
     config = get_config(sources=[kafka.config])
-    events_handler = EventsHandler(config=config)
+    events_handler = EventsHandler(config=config, event_publisher=AsyncMock())
     async with events_handler.get_admin_client() as admin_client:
         # Create a Kafka topic with the cleanup policy set to 'delete'
         topic_policies = [
@@ -91,7 +91,7 @@ async def test_get_policy(kafka: KafkaFixture):
 async def test_set_policy(kafka: KafkaFixture):
     """Verify that `_set_cleanup_policy()` updates the current value"""
     config = get_config(sources=[kafka.config])
-    events_handler = EventsHandler(config=config)
+    events_handler = EventsHandler(config=config, event_publisher=AsyncMock())
     async with events_handler.get_admin_client() as admin_client:
         # Create a Kafka topic with the cleanup policy set to 'compact'
         if not await events_handler._get_cleanup_policy(topic=TEST_TOPIC1):
@@ -155,7 +155,7 @@ async def test_clear_topics_happy(
     config = get_config(sources=[kafka.config])
 
     # Make sure to set policy to "compact" for the topics
-    events_handler = EventsHandler(config=config)
+    events_handler = EventsHandler(config=config, event_publisher=AsyncMock())
     async with events_handler.get_admin_client() as admin_client:
         existing_topics = await admin_client.list_topics()
         for topic in topics_to_clear:

--- a/tests/unit/events/test_events_handler.py
+++ b/tests/unit/events/test_events_handler.py
@@ -58,18 +58,22 @@ def get_expected_records_to_delete(
 
 
 @pytest.mark.parametrize(
-    "topics", [["topic1", "topic2"], []], ids=["BasicTopics", "EmptyTopicsList"]
+    "topics_to_delete",
+    [["topic1", "topic2"], []],
+    ids=["BasicTopics", "EmptyTopicsList"],
 )
 @pytest.mark.parametrize(
     "exclude_internal", [True, False], ids=["DontClearInternal", "ClearInternal"]
 )
-async def test_topics_parameter_behavior(topics: list[str], exclude_internal: bool):
+async def test_topics_parameter_behavior(
+    topics_to_delete: list[str], exclude_internal: bool
+):
     """Test how clear_topics behaves based on the parameters."""
     # Set up a mock to replace the admin client and _get_cleanup_policy() method
     mock = AsyncMock(spec=AIOKafkaAdminClient)
-    mock_topics_info = mock_describe_topics(topics)
+    mock_topics_info = mock_describe_topics(topics_to_delete)
     mock.describe_topics.return_value = mock_topics_info
-    mock.list_topics.return_value = INTERNAL_TOPICS + topics
+    mock.list_topics.return_value = INTERNAL_TOPICS + topics_to_delete
     policy_mock = AsyncMock()
     policy_mock.return_value = "delete"
 
@@ -79,17 +83,38 @@ async def test_topics_parameter_behavior(topics: list[str], exclude_internal: bo
     handler.get_admin_client = lambda: asyncnullcontext(mock)  # type: ignore [method-assign]
 
     # Call the clear_topics method
-    await handler.clear_topics(topics=topics, exclude_internal=exclude_internal)
-
-    # If topics is empty, the list_topics method should have been called to get all topics
-    if not topics:
-        mock.list_topics.assert_awaited_once()
-    else:
-        # ... otherwise, it should not have been called
-        mock.list_topics.assert_not_called()
+    await handler.clear_topics(
+        topics=topics_to_delete, exclude_internal=exclude_internal
+    )
 
     # Assert that the delete records function is called with the expected args
-    expected_args = get_expected_records_to_delete(mock_topics_info, exclude_internal)
-    mock.delete_records.assert_awaited_once()
-    actual_args = mock.delete_records.await_args[0][0]
-    assert actual_args.keys() == expected_args.keys()
+    assert mock.delete_records.await_count == len(topics_to_delete)
+    if topics_to_delete:
+        await_args_list = mock.delete_records.await_args_list
+        expected_deleted_topics = []
+        if not (topics_to_delete or exclude_internal):
+            expected_deleted_topics.extend(INTERNAL_TOPICS)
+        elif topics_to_delete:
+            expected_deleted_topics = topics_to_delete
+
+        # Assert that we made one delete_records call for each desired topic
+        assert len(await_args_list) == len(expected_deleted_topics)
+        actually_deleted_topics = []
+
+        for call in await_args_list:
+            # Extract the call arg we actually care about: the records_to_delete arg
+            records_to_delete_dict = call[0][0]
+
+            # Only one topic should have been cleared at a time
+            items = [_ for _ in records_to_delete_dict.items()]
+            assert len(items) == 1
+
+            # Verify the supplied key was a TopicPartition, the value a RecordsToDelete
+            key, value = items[0]
+            assert isinstance(key, TopicPartition)
+            assert isinstance(value, RecordsToDelete)
+            # Get the topic from the TopicPartition (key) and track it
+            actually_deleted_topics.append(key[0])
+
+        # Verify the topics submitted for deletion were the expected topics
+        assert actually_deleted_topics == expected_deleted_topics


### PR DESCRIPTION
This adds a way to clear out compacted topics by temporarily setting the `cleanup.policy` to `delete`, performing the delete, then setting the policy back to what it was before.

It also updates all the template files and license headers, so there's some clutter. These changes will go into version `4.0.0`, so that's why the project version was not modified.