### PR TITLE
Enable extended json (GSI-1819)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sms"
-version = "4.1.0"
+version = "4.2.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/state-management-service):
 ```bash
-docker pull ghga/state-management-service:4.1.0
+docker pull ghga/state-management-service:4.2.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/state-management-service:4.1.0 .
+docker build -t ghga/state-management-service:4.2.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -38,7 +38,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/state-management-service:4.1.0 --help
+docker run -p 8080:8080 ghga/state-management-service:4.2.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -102,7 +102,7 @@ components:
 info:
   description: A service for basic infrastructure technology state management.
   title: State Management Service
-  version: 4.1.0
+  version: 4.2.0
 openapi: 3.1.0
 paths:
   /documents/permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "sms"
-version = "4.1.0"
+version = "4.2.0"
 description = "State Management Service - Provides a REST API for basic infrastructure technology state management."
 dependencies = [
     "typer >= 0.12",


### PR DESCRIPTION
This PR enables us to use extended JSON so we can work with non-JSON-serializable types like datetimes and UUIDs.

The problem was that because our MongoDB document data and search criteria was coming through the REST API as JSON, the SMS didn't have the original field type information. When upserting docs through the SMS, we could supply a stringified UUID, but not a native UUID. Likewise, we could search for stringified UUIDs, but we would not get a match if the data was originally stored as a UUID.

This PR lets us mitigate this challenge by specifying UUID and datetime fields with `"$uuid"` and `"$date"`, respectively.

Bumps the version to `4.2.0`.